### PR TITLE
fix extract upgrade models 

### DIFF
--- a/postprocessing/comstockpostproc/utils/hpc.py
+++ b/postprocessing/comstockpostproc/utils/hpc.py
@@ -70,7 +70,7 @@ def extract_models_from_simulation_output(yml_path, up_id='up00', output_vars=[]
     df_bstock_csv = pd.read_csv(path_to_buildstock_file, index_col=i)
 
     # Load results.csv
-    path_to_zipped_results_file = os.path.join(results_csv_path, 'results_up00.csv.gz')
+    path_to_zipped_results_file = os.path.join(results_csv_path, f'results_{up_id}.csv.gz')
     df_results_csv = pd.read_csv(path_to_zipped_results_file, compression='infer', header=0, sep=',', quotechar='"', index_col='building_id')
 
     # Untar all relevant models in a single job's .tar.gz and pull required zip files into folder structure (.idf, .osm)

--- a/postprocessing/comstockpostproc/utils/hpc.py
+++ b/postprocessing/comstockpostproc/utils/hpc.py
@@ -72,6 +72,11 @@ def extract_models_from_simulation_output(yml_path, up_id='up00', output_vars=[]
     # Load results.csv
     path_to_zipped_results_file = os.path.join(results_csv_path, f'results_{up_id}.csv.gz')
     df_results_csv = pd.read_csv(path_to_zipped_results_file, compression='infer', header=0, sep=',', quotechar='"', index_col='building_id')
+    
+    if up_id is not "up_00":
+        # load baseline results.csv
+        path_to_baseline_results_file = os.path.join(results_csv_path, 'results_up00.csv.gz')
+        baseline_results_csv = pd.read_csv(path_to_baseline_results_file, compression='infer', header=0, sep=',', quotechar='"', index_col='building_id')
 
     # Untar all relevant models in a single job's .tar.gz and pull required zip files into folder structure (.idf, .osm)
     def model_extract(tar_path, tar_to_zip_dict, tar_to_id_dict, bldgid_to_zip_dict, model_files_dir):
@@ -212,7 +217,11 @@ def extract_models_from_simulation_output(yml_path, up_id='up00', output_vars=[]
     for subdirs, dirs, files in os.walk(model_files_dir):
         for directory in dirs:
             bldg_id = int(directory.split('_')[-3].replace('BLDG', '').lstrip('0'))
-            epw_name = list(df_results_csv.loc[df_results_csv.index==bldg_id, 'build_existing_model.changebuildinglocation_weather_file_name'])[0]
+            if up_id == 'up00':
+                epw_name = list(df_results_csv.loc[df_results_csv.index==bldg_id, 'build_existing_model.changebuildinglocation_weather_file_name'])[0]
+            else:
+                # look for epw name in baseline results csv
+                epw_name = list(baseline_results_csv.loc[baseline_results_csv.index==bldg_id, 'build_existing_model.changebuildinglocation_weather_file_name'])[0]
             epw_zip = zipfile.ZipFile(weather_file_dir)
             model_dir = os.path.join(model_files_dir, directory)
             epw = epw_zip.extract(epw_name, path=model_dir)

--- a/postprocessing/comstockpostproc/utils/hpc.py
+++ b/postprocessing/comstockpostproc/utils/hpc.py
@@ -73,7 +73,7 @@ def extract_models_from_simulation_output(yml_path, up_id='up00', output_vars=[]
     path_to_zipped_results_file = os.path.join(results_csv_path, f'results_{up_id}.csv.gz')
     df_results_csv = pd.read_csv(path_to_zipped_results_file, compression='infer', header=0, sep=',', quotechar='"', index_col='building_id')
     
-    if up_id is not "up_00":
+    if up_id is not "up00":
         # load baseline results.csv
         path_to_baseline_results_file = os.path.join(results_csv_path, 'results_up00.csv.gz')
         baseline_results_csv = pd.read_csv(path_to_baseline_results_file, compression='infer', header=0, sep=',', quotechar='"', index_col='building_id')


### PR DESCRIPTION
Pull request overview
---------------------

Previously, cspp.utils.hpc.extract_models_from_simulation_output would only work with up_id='up00'. The results csv that the script would look in was hard-coded to the baseline results file. Additionally, the script would not find the weather file for upgrade runs, since that information is only in the baseline results csv.

This PR fixes it so you can extract models from upgrade runs, and find the correct weather file for that run.

### Pull Request Author

This pull request makes changes to (select all the apply):
 - [ ] Documentation
 - [ ] Infrastructure (includes singularity image, buildstock batch, dependencies, continuous integration tests)
 - [ ] Sampling
 - [ ] Workflow Measures
 - [ ] Upgrade Measures
 - [ ] Reporting Measures
 - [x] Postprocessing

Author pull request checklist:
<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: data and method additions, changes, tests
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] Reviewed change documentation
 - [ ] Ensured code files contain License reference
 - [ ] Results differences are reasonable
 - [ ] CI status: all tests pass

#### ComStock Licensing Language - Add to Beginning of Each Code File
```
# ComStock™, Copyright (c) 2023 Alliance for Sustainable Energy, LLC. All rights reserved.
# See top level LICENSE.txt file for license terms.
```
