### PR TITLE
HP-RTU advanced performance replace hardcoded curve to `.evaluate` 2

### DIFF
--- a/resources/measures/upgrade_hvac_add_heat_pump_rtu/measure.rb
+++ b/resources/measures/upgrade_hvac_add_heat_pump_rtu/measure.rb
@@ -1549,20 +1549,17 @@ class AddHeatPumpRtu < OpenStudio::Measure::ModelMeasure
       # design - temperature determined by design days in specified weather file
       oa_temp_c = wntr_design_day_temp_c
       dns_htg_load_at_dsn_temp = orig_htg_coil_gross_cap
-      hp_derate_factor_at_dsn = 0.93607915412 + -0.005481563544*ia_temp_c + -8.5897908e-06*ia_temp_c**2 + 0.02491053192*oa_temp_c +5.3087076e-05*oa_temp_c**2 + -0.000155750364*ia_temp_c*oa_temp_c
-      # TODO: replace with evaluate
+      hp_derate_factor_at_dsn = heat_cap_ft4.evaluate(ia_temp_c, oa_temp_c)
       req_rated_hp_cap_at_47f_to_meet_load_at_dsn = dns_htg_load_at_dsn_temp / hp_derate_factor_at_dsn
       # 0F
       oa_temp_c = -17.7778
       dns_htg_load_at_0f = htg_load_slope*(-17.7778) + htg_load_intercept
-      hp_derate_factor_at_0f = 0.93607915412 + -0.005481563544*ia_temp_c + -8.5897908e-06*ia_temp_c**2 + 0.02491053192*oa_temp_c + 5.3087076e-05*oa_temp_c**2 + -0.000155750364*ia_temp_c*oa_temp_c
-      # TODO: replace with evaluate
+      hp_derate_factor_at_0f = heat_cap_ft4.evaluate(ia_temp_c, oa_temp_c)
       req_rated_hp_cap_at_47f_to_meet_load_at_0f = dns_htg_load_at_0f / hp_derate_factor_at_0f
       # 17F
       oa_temp_c = -8.33333
       dns_htg_load_at_17f = htg_load_slope*(-8.33333) + htg_load_intercept
-      hp_derate_factor_at_17f = 0.93607915412 + -0.005481563544*ia_temp_c + -8.5897908e-06*ia_temp_c**2 + 0.02491053192*oa_temp_c + 5.3087076e-05*oa_temp_c**2 + -0.000155750364*ia_temp_c*oa_temp_c
-      # TODO: replace with evaluate
+      hp_derate_factor_at_17f = heat_cap_ft4.evaluate(ia_temp_c, oa_temp_c)
       req_rated_hp_cap_at_47f_to_meet_load_at_17f = dns_htg_load_at_17f / hp_derate_factor_at_17f
       # 47F - note that this is rated conditions, so "derate" factor is either 1 from the curve, or will be normlized to 1 by E+ during simulation
       oa_temp_c = 8.33333
@@ -1572,8 +1569,7 @@ class AddHeatPumpRtu < OpenStudio::Measure::ModelMeasure
       # user-specified design
       oa_temp_c = hp_sizing_temp_c
       dns_htg_load_at_user_dsn_temp = htg_load_slope*hp_sizing_temp_c + htg_load_intercept
-      hp_derate_factor_at_user_dsn = 0.93607915412 + -0.005481563544*ia_temp_c + -8.5897908e-06*ia_temp_c**2 + 0.02491053192*oa_temp_c + 5.3087076e-05*oa_temp_c**2 + -0.000155750364*ia_temp_c*oa_temp_c
-      # TODO: replace with evaluate
+      hp_derate_factor_at_user_dsn = heat_cap_ft4.evaluate(ia_temp_c, oa_temp_c)
       req_rated_hp_cap_at_user_dsn_to_meet_load_at_user_dsn = dns_htg_load_at_user_dsn_temp / hp_derate_factor_at_user_dsn
 
       # determine heat pump system sizing based on user-specified sizing temperature and user-specified maximum upsizing limits

--- a/resources/measures/upgrade_hvac_add_heat_pump_rtu/measure.xml
+++ b/resources/measures/upgrade_hvac_add_heat_pump_rtu/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>add_heat_pump_rtu</name>
   <uid>f4567a68-27f2-4a15-ae91-ba0f35cd08c7</uid>
-  <version_id>2104cc7f-d24a-4090-a8ff-68f9cf93d5c9</version_id>
-  <version_modified>2024-05-08T16:12:33Z</version_modified>
+  <version_id>17898046-d732-48c6-8e54-206e5ed52eac</version_id>
+  <version_modified>2024-05-08T16:35:37Z</version_modified>
   <xml_checksum>5E2576E4</xml_checksum>
   <class_name>AddHeatPumpRtu</class_name>
   <display_name>add_heat_pump_rtu</display_name>
@@ -220,7 +220,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>41CCC9ED</checksum>
+      <checksum>8794265D</checksum>
     </file>
     <file>
       <filename>performance_maps_hprtu_std.json</filename>


### PR DESCRIPTION
Pull request overview
---------------------

- coming from this https://github.com/NREL/ComStock/pull/166
- forgot to commit the `evaluate` replacement commit 😓

### Pull Request Author

This pull request makes changes to (select all the apply):
 - [ ] Documentation
 - [ ] Infrastructure (includes singularity image, buildstock batch, dependencies, continuous integration tests)
 - [ ] Sampling
 - [ ] Workflow Measures
 - [X] Upgrade Measures
 - [ ] Reporting Measures
 - [ ] Postprocessing

Author pull request checklist:
<!--- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->
 - [ ] Tagged the pull request with the appropriate label (documentation, infrastructure, sampling, workflow measure, upgrade measure, reporting measure, postprocessing) to help categorize changes in the release notes.
 - [ ] Added tests for new measures
 - [X] Updated measure .xml(s)
 - [ ] Register values added to `comstock_column_definitions.csv`
 - [ ] Both `options_lookup.tsv` files updated
 - [ ] 10k+ test run
 - [ ] Change documentation written
 - [ ] Measure documentation written
 - [ ] ComStock documentation updated
 - [ ] Changes reflected in example `.yml` files
 - [ ] Changes reflected in `README.md` files
 - [ ] Added 'See ComStock License' language to first two lines of each code file
 - [ ] Implements corresponding measure tests and indexing path in `test/measure_tests.txt` or/and `test/resource_measure_tests.txt`
 - [ ] All new and existing tests pass the CI

### Review Checklist

This will not be exhaustively relevant to every PR.
 - [ ] Perform a code review on GitHub
 - [ ] All related changes have been implemented: data and method additions, changes, tests
 - [ ] If fixing a defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] Reviewed change documentation
 - [ ] Ensured code files contain License reference
 - [ ] Results differences are reasonable
 - [ ] Make sure the newly added measures has been added with tests and indexed properly
 - [ ] CI status: all tests pass