### PR TITLE
Updates gap model for 2025 Release 2

### DIFF
--- a/postprocessing/comstockpostproc/gap/run_commercial_gap.py
+++ b/postprocessing/comstockpostproc/gap/run_commercial_gap.py
@@ -10,17 +10,17 @@ logging.basicConfig(level='DEBUG')  # Use DEBUG, INFO, or WARNING
 logger = logging.getLogger(__name__)
 
 def main():
-    gap_model = CommercialGap(                 
-                    truth_data_version='v01', # Version of truth data 
-                    reload_from_saved=False, 
-                    resstock_version='2024_amy2018_release_2', 
-                    comstock_version='amy2018_r1_2025',
+    gap_model = CommercialGap(
+                    truth_data_version='v01', # Version of truth data
+                    reload_from_saved=False,
+                    resstock_version='2024_amy2018_release_2',
+                    comstock_version='amy2018_r2_2025',
                     basis_lrd_name='First Energy PA',
                     res_allocation_method='EIA',
                     com_allocation_method='EIA',
                     gap_allocation_method='CBECS',
                     trim_negative_gap=True)
-    
+
     gap_model.save_gap_profiles()
     gap_model.plot_profiles('BA', ['PJM', 'ERCO', 'CISO'])
     gap_model.annual_comparison_plot()

--- a/postprocessing/comstockpostproc/naming_mixin.py
+++ b/postprocessing/comstockpostproc/naming_mixin.py
@@ -534,7 +534,8 @@ class NamingMixin():
         ANN_TOT_NET_ENGY_KBTU,
         ANN_TOT_NET_ELEC_KBTU,
         ANN_TOT_GAS_KBTU,
-        ANN_TOT_OTHFUEL_KBTU,
+        ANN_TOT_FUELOIL_KBTU,
+        ANN_TOT_PROPANE_KBTU,
         ANN_TOT_DISTHTG_KBTU,
         ANN_TOT_DISTCLG_KBTU
     ]
@@ -543,7 +544,8 @@ class NamingMixin():
     COLS_PURCHASED_ANN_ENGY = [
         ANN_PURCHASED_ELEC_KBTU,
         ANN_TOT_GAS_KBTU,
-        ANN_TOT_OTHFUEL_KBTU,
+        ANN_TOT_FUELOIL_KBTU,
+        ANN_TOT_PROPANE_KBTU,
         ANN_TOT_DISTHTG_KBTU,
         ANN_TOT_DISTCLG_KBTU
     ]


### PR DESCRIPTION
Pull request overview
---------------------
Updates the gap model to use the 2025 Release 2 dataset. Made some very minor changes to pass ComStock version through the code correctly instead of relying on constructor defaults. Made a minor change to accommodate propane/fuel oil. Tested and used to generate gap results for 2025 Release 2.


