### PR TITLE
Account for net thermal radiation exchange in load components

### DIFF
--- a/measures/loads_summary/measure.rb
+++ b/measures/loads_summary/measure.rb
@@ -93,6 +93,7 @@ class LoadsSummary < OpenStudio::Measure::ReportingMeasure
       'Surface Window Inside Face Shade Net Infrared Heat Transfer Rate',
       'Surface Window Inside Face Gap between Shade and Glazing Zone Convection Heat Gain Rate',
       'Surface Inside Face Convection Heat Gain Energy',
+      'Surface Inside Face Net Surface Thermal Radiation Heat Gain Energy',
       'Zone Infiltration Sensible Heat Gain Energy',
       'Zone Infiltration Sensible Heat Loss Energy',
       'Zone Mechanical Ventilation Heating Load Increase Energy',

--- a/measures/loads_summary/measure.xml
+++ b/measures/loads_summary/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>loads_summary</name>
   <uid>82d9a22a-80ea-4fa7-a57f-77ce8fa4be76</uid>
-  <version_id>39d399b1-21cc-4d50-a382-827a223aa685</version_id>
-  <version_modified>2025-09-18T22:14:08Z</version_modified>
+  <version_id>316aa018-05a3-4771-810f-5cf86d3b2108</version_id>
+  <version_modified>2025-09-19T21:24:10Z</version_modified>
   <xml_checksum>58F01CAA</xml_checksum>
   <class_name>LoadsSummary</class_name>
   <display_name>loads_summary</display_name>
@@ -82,13 +82,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5401B2CA</checksum>
+      <checksum>A61EEA7E</checksum>
     </file>
     <file>
       <filename>python_plugin.py.erb</filename>
       <filetype>erb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>C3AF5967</checksum>
+      <checksum>7E6D707F</checksum>
     </file>
     <file>
       <filename>report.html.in</filename>

--- a/measures/loads_summary/resources/python_plugin.py.erb
+++ b/measures/loads_summary/resources/python_plugin.py.erb
@@ -101,6 +101,7 @@ WIN_CONV_VARS = {k: val for k, val in WIN_OUT_VAR_MAP.items() if val[0] in ['swi
 
 SURF_OUT_VAR_MAP = {
     0: ('sifchge', 'Surface Inside Face Convection Heat Gain Energy'),
+    1: ('sifnstrhge', 'Surface Inside Face Net Surface Thermal Radiation Heat Gain Energy')
     }
 
 SURF_MAP = {
@@ -560,71 +561,82 @@ class LoadSummary(EnergyPlusPlugin):
 
             # subtract area-weighted delayed internal and windows gains from internal surface convections gains
             int_surf_total_conv = 0
-            for var_key in SURF_OUT_VAR_MAP:
-                for surf_type_key in INT_SURF_KEYS:
-                    for surf_key, surf_name in self.surf_name_map[z][surf_type_key].items():
-                        if surf_name:
-                            # get surface area fraction
-                            frac = self.all_surf_frac_map[z][surf_type_key][surf_key]
-                            # get convection gain value
-                            surf_conv = self.surf_out_var_dict[z][surf_type_key][surf_key][var_key][1]
-                            if surf_type_key in FLR_KEYS:
-                                # for floor surfaces, subtract delayed window solar radiation
-                                int_surf_total_conv += (
-                                    surf_conv * -1
-                                    ) - (
-                                    (tot_del_int_gains + win_del_ir_gains) * frac
-                                    ) - (
-                                    win_rts_solar_rad * self.flr_surf_frac_map[z][surf_type_key][surf_key]
-                                )
-                            else:
-                                # subtract delayed internal gains
-                                int_surf_total_conv += (
-                                    surf_conv * -1
-                                    ) - (
-                                    (tot_del_int_gains + win_del_ir_gains) * frac
-                                )
+            for surf_type_key in INT_SURF_KEYS:
+                for surf_key, surf_name in self.surf_name_map[z][surf_type_key].items():
+                    if surf_name:
+                        # get surface area fraction
+                        frac = self.all_surf_frac_map[z][surf_type_key][surf_key]
+                        # get convection gain value
+                        var_key = 0 # Surface Inside Face Convection Heat Gain Energy
+                        surf_conv = self.surf_out_var_dict[z][surf_type_key][surf_key][var_key][1]
+                        var_key = 1 # Surface Inside Face Net Surface Thermal Radiation Heat Gain Energy
+                        surf_rad = self.surf_out_var_dict[z][surf_type_key][surf_key][var_key][1]
+                        if surf_type_key in FLR_KEYS:
+                            # for floor surfaces, subtract delayed window solar radiation
+                            int_surf_total_conv += (
+                                surf_conv * -1
+                                ) + (
+                                surf_rad * -1
+                                ) - (
+                                (tot_del_int_gains + win_del_ir_gains) * frac
+                                ) - (
+                                win_rts_solar_rad * self.flr_surf_frac_map[z][surf_type_key][surf_key]
+                            )
+                        else:
+                            # subtract delayed internal gains
+                            int_surf_total_conv += (
+                                surf_conv * -1
+                                ) + (
+                                surf_rad * -1
+                                ) - (
+                                (tot_del_int_gains + win_del_ir_gains) * frac
+                            )
 
             ext_surf_conv = {}
-            for var_key in SURF_OUT_VAR_MAP:
-                for ext_surf_type_key in EXT_SURF_KEYS:
-                    ext_surf_conv[ext_surf_type_key] = 0
-                    for ext_surf_key, surf_name in self.surf_name_map[z][ext_surf_type_key].items():
-                        if surf_name:
-                            # get surface area fraction
-                            all_surf_frac = self.all_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
-                            ext_surf_frac = self.ext_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
-                            # get convection gain value
-                            surf_conv = self.surf_out_var_dict[z][ext_surf_type_key][ext_surf_key][var_key][1]
-                            # subtract delayed internal gains
-                            if ext_surf_type_key in WIN_KEYS:
-                                # for window surfaces, add gap between shade and glazing convective gain
-                                for win_var in WIN_CONV_VARS:
-                                    ext_surf_conv[ext_surf_type_key] += ((
-                                    surf_conv * -1                                                                          # reported surface convection
-                                    ) - (
-                                    tot_del_int_gains * all_surf_frac                                                       # subtract delayed internal gains
-                                    ) + (
-                                    self.sec_per_ts * self.win_out_var_dict[z][ext_surf_type_key][ext_surf_key][win_var][1] # add gap between shade and glazing convective gain
-                                    ) + (
-                                    int_surf_total_conv * ext_surf_frac                                                     # add exterior surface-weighted internal surface convection
-                                    ))
+            for ext_surf_type_key in EXT_SURF_KEYS:
+                ext_surf_conv[ext_surf_type_key] = 0
+                for ext_surf_key, surf_name in self.surf_name_map[z][ext_surf_type_key].items():
+                    if surf_name:
+                        # get surface area fraction
+                        all_surf_frac = self.all_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
+                        ext_surf_frac = self.ext_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
+                        # get convection gain value
+                        var_key = 0 # Surface Inside Face Convection Heat Gain Energy
+                        surf_conv = self.surf_out_var_dict[z][ext_surf_type_key][ext_surf_key][var_key][1]
+                        var_key = 1 # Surface Inside Face Net Surface Thermal Radiation Heat Gain Energy
+                        surf_rad = self.surf_out_var_dict[z][ext_surf_type_key][ext_surf_key][var_key][1]
+                        # subtract delayed internal gains
+                        if ext_surf_type_key in WIN_KEYS:
+                            # for window surfaces, add gap between shade and glazing convective gain
+                            for win_var in WIN_CONV_VARS:
+                                ext_surf_conv[ext_surf_type_key] += ((
+                                surf_conv * -1                                                                          # reported surface convection
+                                ) + (
+                                surf_rad * -1                                                                           # reported surface radiation
+                                ) - (
+                                tot_del_int_gains * all_surf_frac                                                       # subtract delayed internal gains
+                                ) + (
+                                self.sec_per_ts * self.win_out_var_dict[z][ext_surf_type_key][ext_surf_key][win_var][1] # add gap between shade and glazing convective gain
+                                ) + (
+                                int_surf_total_conv * ext_surf_frac                                                     # add exterior surface-weighted internal surface convection
+                                ))
 
-                            else:
-                                ext_surf_conv[ext_surf_type_key] += (
-                                    surf_conv * -1
-                                    ) - (
-                                    (tot_del_int_gains + win_del_ir_gains) * all_surf_frac
-                                    ) + (
-                                    int_surf_total_conv * ext_surf_frac
+                        else:
+                            ext_surf_conv[ext_surf_type_key] += (
+                                surf_conv * -1
+                                ) + (
+                                surf_rad * -1
+                                ) - (
+                                (tot_del_int_gains + win_del_ir_gains) * all_surf_frac
+                                ) + (
+                                int_surf_total_conv * ext_surf_frac
+                            )
+                            if surf_type_key in FLR_KEYS:
+                                # for floor surfaces, subtract delayed window solar radiation multiplied by floor surface fraction
+                                flr_surf_frac = self.flr_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
+                                ext_surf_conv[ext_surf_type_key] -= (
+                                    win_rts_solar_rad * flr_surf_frac
                                 )
-                                if surf_type_key in FLR_KEYS:
-                                    # for floor surfaces, subtract delayed window solar radiation multiplied by floor surface fraction
-                                    flr_surf_frac = self.flr_surf_frac_map[z][ext_surf_type_key][ext_surf_key]
-                                    ext_surf_conv[ext_surf_type_key] -= (
-                                        win_rts_solar_rad * flr_surf_frac
-                                    )
-
 
             # update component dict
             sys_rate = 0


### PR DESCRIPTION
Pull request overview
---------------------
This change subtracts "Surface Inside Face Net Surface Thermal Radiation Heat Gain Energy" from each surface, removing heat gains and losses from radiant exchange from its load attribution. This was suggested after high convection loads from ground surfaces in cooling. Window, roof, and wall surfaces were heating the ground through radiant exchange, causing the ground to be over-represented in the load components. This change does not account for any time delay.

### Pull Request Author
 - [x] Reporting Measures

### Pull Request Author Checklist:
 - [x] Tagged the pull request with the appropriate label (documentation, infrastructure, sampling, workflow measure, upgrade measure, reporting measure, postprocessing) to help categorize changes in the release notes.
 - [x] Added or edited tests for measures that adequately cover anticipated cases
 - [x] Ran 10k+ test run and checked failure rate to make sure no new errors were introduced

### Pull Request Reviewer Checklist:
 - [ ] Perform a code review on GitHub
 - [ ] All changes have been implemented: data, methods, tests, documentation