### PR TITLE
Correct climate zone value in ChangeBuildingLocation

### DIFF
--- a/resources/measures/ChangeBuildingLocation/measure.rb
+++ b/resources/measures/ChangeBuildingLocation/measure.rb
@@ -338,10 +338,10 @@ class ChangeBuildingLocation < OpenStudio::Measure::ModelMeasure
     # set climate zone
     climate_zones.clear
     if args['climate_zone'].include?('CEC')
-      climate_zones.setClimateZone('CEC', args['climate_zone'].gsub('T24-CEC', ''))
+      climate_zones.setClimateZone('CEC', args['climate_zone'].gsub('CEC T24-CEC', '').gsub('T24-CEC', ''))
       runner.registerInfo("Setting Climate Zone to #{climate_zones.getClimateZones('CEC').first.value}")
     else
-      climate_zones.setClimateZone('ASHRAE', args['climate_zone'].gsub('ASHRAE 169-2006-', ''))
+      climate_zones.setClimateZone('ASHRAE', args['climate_zone'].gsub(/ASHRAE .*-.*-/, ''))
       runner.registerInfo("Setting Climate Zone to #{climate_zones.getClimateZones('ASHRAE').first.value}")
     end
 

--- a/resources/measures/ChangeBuildingLocation/measure.xml
+++ b/resources/measures/ChangeBuildingLocation/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.1</schema_version>
   <name>change_building_location</name>
   <uid>d4db4971-f5ba-11e3-a3ac-0800200c9a66</uid>
-  <version_id>1123200a-7a26-4e02-bb9f-7578d61659b8</version_id>
-  <version_modified>2025-09-03T19:24:58Z</version_modified>
+  <version_id>afb5d5ff-dd1b-435f-a961-3db03394e180</version_id>
+  <version_modified>2026-01-21T18:24:44Z</version_modified>
   <xml_checksum>057E8D9D</xml_checksum>
   <class_name>ChangeBuildingLocation</class_name>
   <display_name>ChangeBuildingLocation</display_name>
@@ -334,7 +334,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4B231F82</checksum>
+      <checksum>C94935F4</checksum>
     </file>
     <file>
       <filename>epw.rb</filename>


### PR DESCRIPTION
Pull request overview
---------------------
This fixes an issue where climate zone values could get set prepended with ASHRAE 169-2013 instead of just the value, e.g. 'ASHRAE 169-2013-4A' instead of '4A'. 

### Pull Request Author
 - [x] Workflow Measures

### Pull Request Author Checklist:
 - [x] Tagged the pull request with the appropriate label (documentation, infrastructure, sampling, workflow measure, upgrade measure, reporting measure, postprocessing) to help categorize changes in the release notes.
 - [x] Ran 10 test run and checked failure rate to make sure no new errors were introduced

### Pull Request Reviewer Checklist:
 - [x] Perform a code review on GitHub
 - [x] All changes have been implemented: data, methods, tests, documentation
 - [x] Check edited measure .xml files updated
