### PR TITLE
Updates building type end use fuel type plots

### DIFF
--- a/postprocessing/compare_comstock_to_cbecs.py.template
+++ b/postprocessing/compare_comstock_to_cbecs.py.template
@@ -87,7 +87,7 @@ def main():
                                         comstock_list=[comstock],
                                         upgrade_id='All',
                                         make_comparison_plots=True,
-                                        make_hvac_plots=True)
+                                        make_hvac_plots=False)
     comp.export_to_csv_wide()  # May comment this out after run once
 
 # Code to execute the script

--- a/postprocessing/comstockpostproc/plotting_mixin.py
+++ b/postprocessing/comstockpostproc/plotting_mixin.py
@@ -1314,6 +1314,14 @@ class PlottingMixin():
 
         # Extract the units from the name of the first column
         units = self.nice_units(self.units_from_col_name(wtd_end_use_cols[0]))
+        hue_order = list(color_map.keys())
+        palette = [color_map[name] for name in hue_order]
+        row_name = 'Fuel and End Use'
+        row_label_map = {
+            col: self.col_name_to_nice_name(col).replace(' Energy Consumption', '')
+            for col in wtd_end_use_cols
+        }
+        row_order = [row_label_map[col] for col in wtd_end_use_cols]
 
         for bldg_type, bldg_type_df in df.groupby(self.BLDG_TYPE, observed=True):
             for group_by in group_bys:
@@ -1347,18 +1355,28 @@ class PlottingMixin():
                     var_name=var_name,
                     value_name=val_name
                 )
-                # logger.debug(tots_long)
+                tots_long[column_for_grouping] = pd.Categorical(
+                    tots_long[column_for_grouping].astype(str),
+                    categories=hue_order,
+                    ordered=True,
+                )
+                tots_long[row_name] = pd.Categorical(
+                    tots_long[var_name].map(row_label_map),
+                    categories=row_order,
+                    ordered=True,
+                )
 
                 g = sns.catplot(
                     data=tots_long,
                     x=x_col,
                     y=val_name,
-                    row=var_name,
+                    row=row_name,
                     hue=column_for_grouping,
                     estimator=agg_method,
                     order=x_order,
-                    hue_order=list(color_map.keys()),
-                    palette=color_map.values(),
+                    row_order=row_order,
+                    hue_order=hue_order,
+                    palette=palette,
                     sharex=False,
                     kind='bar',
                     errorbar=None,
@@ -1373,10 +1391,8 @@ class PlottingMixin():
                 for ax in g.axes.flatten():
                     # Improve the title and move to the y-axis label
                     ax_title = ax.get_title()
-                    ax_title = ax_title.replace(f'{var_name} = ', '')
-                    ax_units = self.units_from_col_name(ax_title)
-                    ax_title = self.col_name_to_nice_name(ax_title)
-                    ax_title = ax_title.replace('Energy Consumption', f'({ax_units})')
+                    ax_title = ax_title.replace(f'{row_name} = ', '')
+                    ax_title = f'{ax_title} ({units})'
                     ax_title = ax_title.replace(' ', '\n')
                     ax.set_ylabel(ax_title, rotation=0, ha='right')
                     ax.set_title('')


### PR DESCRIPTION
Pull request overview
---------------------
<!--- DESCRIBE PURPOSE OF THIS PULL REQUEST -->
Fixes issue where the building-type-specific energy by end use and fuel type plots were having legend labels swapped, so the plot data was getting incorrect labels for the runs being evaluated.



### Pull Request Author
This pull request makes changes to (select all the apply):
 - [x] Postprocessing

### Pull Request Author Checklist:
<!--- Base checklist. Remove list items that do no apply. -->
 - [x] Tagged the pull request with the appropriate label (documentation, infrastructure, sampling, workflow measure, upgrade measure, reporting measure, postprocessing) to help categorize changes in the release notes.

### Pull Request Reviewer Checklist:
<!--- Base checklist. Remove list items that do no apply. -->
 - [x] Perform a code review on GitHub
 - [x] Run postprocessing and ensure proper functionality with no new errors
 
#### ComStock Licensing Language - Add to Beginning of Each Code File
```
# ComStock™, Copyright (c) 2025 Alliance for Sustainable Energy, LLC. All rights reserved.
# See top level LICENSE.txt file for license terms.
```
